### PR TITLE
Remove env section from myapp-container

### DIFF
--- a/Resources/Day11/readme.md
+++ b/Resources/Day11/readme.md
@@ -45,7 +45,6 @@ spec:
   containers:
   - name: myapp-container
     image: busybox:1.28
-    env:
     command: ['sh', '-c', 'echo The app is running! && sleep 3600']
   initContainers:
   - name: init-myservice


### PR DESCRIPTION
Removed the env section from myapp-container in readme.  As it was confusing as if commands object come's under env: